### PR TITLE
feat: CLIN-1211 - add new born

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,23 @@ Note: the RPT token needs to contain an attribute **fhir_practitioner_id** equal
   }
 }
 ```
+**New born body example:**
+
+Specific for new borns, `mrn` and `ramq` can be empty in `patient` but `mother_ramq` is required in `additional_info`.
+
+```json
+"patient": {
+    "ep": "CHUSJ",
+    ...
+    // no mrn or ramq is needed
+    ...
+    "additional_info": {
+      "is_new_born": true,
+      "mother_ramq": "RAMQ12341236"
+    }
+}
+```
+
 ### Response
 
 `201 created`

--- a/src/main/java/bio/ferlab/clin/portal/forms/clients/FhirClient.java
+++ b/src/main/java/bio/ferlab/clin/portal/forms/clients/FhirClient.java
@@ -2,6 +2,7 @@ package bio.ferlab.clin.portal.forms.clients;
 
 import bio.ferlab.clin.portal.forms.configurations.CacheConfiguration;
 import bio.ferlab.clin.portal.forms.configurations.FhirConfiguration;
+import bio.ferlab.clin.portal.forms.utils.BundleExtractor;
 import bio.ferlab.clin.portal.forms.utils.FhirUtils;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.PerformanceOptionsEnum;
@@ -20,8 +21,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.EnumSet;
+import java.util.List;
 
-import static bio.ferlab.clin.portal.forms.utils.FhirConsts.*;
+import static bio.ferlab.clin.portal.forms.utils.FhirConst.*;
 
 @Component
 @Getter
@@ -126,6 +128,13 @@ public class FhirClient {
         .encodedJson()
         .execute();
   }
+  
+  /*public Patient findPatientByRamqAndEp(String ramq, String ep) {
+    Bundle bundle = this.findPersonAndPatientByRamq(ramq);
+    BundleExtractor bundleExtractor = new BundleExtractor(getContext(), bundle);
+    final List<Patient> patients = bundleExtractor.getAllResourcesOfType(Patient.class);
+    return patients.stream().filter(p -> p.getManagingOrganization().getReference().equals(FhirUtils.formatResource(new Organization().setId(ep)))).findFirst().orElse(null);
+  }*/
 
   @Cacheable(value = CacheConfiguration.CACHE_CODES_VALUES, sync = true)
   public Bundle fetchCodesAndValues() {

--- a/src/main/java/bio/ferlab/clin/portal/forms/controllers/ConfigController.java
+++ b/src/main/java/bio/ferlab/clin/portal/forms/controllers/ConfigController.java
@@ -19,8 +19,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static bio.ferlab.clin.portal.forms.utils.FhirConsts.DEFAULT_EXAM_SUFFIX;
-import static bio.ferlab.clin.portal.forms.utils.FhirConsts.DEFAULT_HPO_SUFFIX;
+import static bio.ferlab.clin.portal.forms.utils.FhirConst.DEFAULT_EXAM_SUFFIX;
+import static bio.ferlab.clin.portal.forms.utils.FhirConst.DEFAULT_HPO_SUFFIX;
 
 @RestController
 @RequestMapping("/form")

--- a/src/main/java/bio/ferlab/clin/portal/forms/mappers/FhirToConfigMapper.java
+++ b/src/main/java/bio/ferlab/clin/portal/forms/mappers/FhirToConfigMapper.java
@@ -5,7 +5,7 @@ import bio.ferlab.clin.portal.forms.models.config.ExtraType;
 import bio.ferlab.clin.portal.forms.models.config.ValueName;
 import bio.ferlab.clin.portal.forms.models.config.ValueNameExtra;
 import bio.ferlab.clin.portal.forms.services.LabelsService;
-import bio.ferlab.clin.portal.forms.utils.FhirConsts;
+import bio.ferlab.clin.portal.forms.utils.FhirConst;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.r4.model.CodeSystem;
@@ -82,7 +82,7 @@ public class FhirToConfigMapper {
   }
   
   private Extra buildExtra(String code, String lang, List<ValueSet> multiValues) {
-    Optional<ValueSet> byCode = multiValues.stream().filter(vs -> (code + FhirConsts.ABNORMALITIES_SUFFIX).equalsIgnoreCase(vs.getName())).findFirst();
+    Optional<ValueSet> byCode = multiValues.stream().filter(vs -> (code + FhirConst.ABNORMALITIES_SUFFIX).equalsIgnoreCase(vs.getName())).findFirst();
     if(byCode.isPresent()) {
       return Extra.builder().label(getLabel(code, lang)).type(ExtraType.multi_select).options(extractValuesByLang(byCode.get(), lang)).build();
     } else {

--- a/src/main/java/bio/ferlab/clin/portal/forms/mappers/FhirToSearchMapper.java
+++ b/src/main/java/bio/ferlab/clin/portal/forms/mappers/FhirToSearchMapper.java
@@ -1,7 +1,7 @@
 package bio.ferlab.clin.portal.forms.mappers;
 
 import bio.ferlab.clin.portal.forms.models.search.Search;
-import bio.ferlab.clin.portal.forms.utils.FhirConsts;
+import bio.ferlab.clin.portal.forms.utils.FhirConst;
 import bio.ferlab.clin.portal.forms.utils.FhirUtils;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Patient;
@@ -36,10 +36,10 @@ public class FhirToSearchMapper {
   }
   
   private String getRamq(Person person) {
-    return person.getIdentifier().stream().filter(i -> FhirConsts.SYSTEM_RAMQ.equals(i.getType().getCodingFirstRep().getSystem()) && FhirConsts.CODE_RAMQ.equals(i.getType().getCodingFirstRep().getCode())).map(Identifier::getValue).findFirst().orElse(null);
+    return person.getIdentifier().stream().filter(i -> FhirConst.SYSTEM_RAMQ.equals(i.getType().getCodingFirstRep().getSystem()) && FhirConst.CODE_RAMQ.equals(i.getType().getCodingFirstRep().getCode())).map(Identifier::getValue).findFirst().orElse(null);
   }
 
   private String getMrn(Patient patient) {
-    return patient.getIdentifier().stream().filter(i -> FhirConsts.SYSTEM_MRN.equals(i.getType().getCodingFirstRep().getSystem()) && FhirConsts.CODE_MRN.equals(i.getType().getCodingFirstRep().getCode())).map(Identifier::getValue).findFirst().orElse(null);
+    return patient.getIdentifier().stream().filter(i -> FhirConst.SYSTEM_MRN.equals(i.getType().getCodingFirstRep().getSystem()) && FhirConst.CODE_MRN.equals(i.getType().getCodingFirstRep().getCode())).map(Identifier::getValue).findFirst().orElse(null);
   }
 }

--- a/src/main/java/bio/ferlab/clin/portal/forms/mappers/SubmitToFhirMapper.java
+++ b/src/main/java/bio/ferlab/clin/portal/forms/mappers/SubmitToFhirMapper.java
@@ -2,6 +2,7 @@ package bio.ferlab.clin.portal.forms.mappers;
 
 import bio.ferlab.clin.portal.forms.models.submit.Patient;
 import bio.ferlab.clin.portal.forms.models.submit.*;
+import bio.ferlab.clin.portal.forms.utils.FhirConst;
 import bio.ferlab.clin.portal.forms.utils.FhirUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.r4.model.*;
@@ -19,7 +20,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static bio.ferlab.clin.portal.forms.utils.FhirConsts.*;
+import static bio.ferlab.clin.portal.forms.utils.FhirConst.*;
 
 @Component
 public class SubmitToFhirMapper {
@@ -170,6 +171,16 @@ public class SubmitToFhirMapper {
     }).collect(Collectors.toList()));
     
     return all;
+  }
+  
+  public RelatedPerson mapToRelatedPerson(org.hl7.fhir.r4.model.Patient patient, String motherRamq) {
+    final RelatedPerson relatedPerson = new RelatedPerson();
+    relatedPerson.setId(UUID.randomUUID().toString());
+    this.updateIdentifier(relatedPerson.getIdentifier(), SYSTEM_RAMQ, CODE_RAMQ, motherRamq, null);
+    relatedPerson.setPatient(FhirUtils.toReference(patient));
+    relatedPerson.addRelationship().setText("Mother").addCoding().setSystem(SYSTEM_MOTHER).setCode(CODE_MOTHER);
+    relatedPerson.setActive(true);
+    return relatedPerson;
   }
   
   private String getInterpretationCode(Exams.Interpretation interpretation) {

--- a/src/main/java/bio/ferlab/clin/portal/forms/models/builders/NewBornBuilder.java
+++ b/src/main/java/bio/ferlab/clin/portal/forms/models/builders/NewBornBuilder.java
@@ -1,0 +1,37 @@
+package bio.ferlab.clin.portal.forms.models.builders;
+
+import bio.ferlab.clin.portal.forms.clients.FhirClient;
+import bio.ferlab.clin.portal.forms.mappers.SubmitToFhirMapper;
+import bio.ferlab.clin.portal.forms.models.submit.AdditionalInfo;
+import bio.ferlab.clin.portal.forms.utils.FhirUtils;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.RelatedPerson;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+@RequiredArgsConstructor
+public class NewBornBuilder {
+  
+  private final SubmitToFhirMapper mapper;
+  private final AdditionalInfo additionalInfo;
+  private final Patient patient;
+  
+  public Result build() {
+    RelatedPerson relatedPerson = null;
+    if (Boolean.TRUE.equals(additionalInfo.getIsNewBorn())) {
+      additionalInfo.validate();
+      relatedPerson = mapper.mapToRelatedPerson(patient, additionalInfo.getMotherRamq());
+    }
+    return new Result(relatedPerson);
+  }
+  
+  @Getter
+  @AllArgsConstructor
+  public static class Result {
+    private final RelatedPerson relatedPerson;
+  }
+}

--- a/src/main/java/bio/ferlab/clin/portal/forms/models/builders/PatientBuilder.java
+++ b/src/main/java/bio/ferlab/clin/portal/forms/models/builders/PatientBuilder.java
@@ -32,8 +32,10 @@ public class PatientBuilder {
   private Optional<Person> personByMrn = Optional.empty();
   
   public PatientBuilder validateRamqAndMrn() {
-    if (StringUtils.isAllBlank(patient.getRamq(), patient.getMrn())) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "patient.ramq and patient.mrn can't be both empty");
+    if (!Boolean.TRUE.equals(patient.getAdditionalInfo().getIsNewBorn())) {
+      if (StringUtils.isAllBlank(patient.getRamq(), patient.getMrn())) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "patient.ramq and patient.mrn can't be both empty");
+      }
     }
     return this;
   }

--- a/src/main/java/bio/ferlab/clin/portal/forms/models/submit/AdditionalInfo.java
+++ b/src/main/java/bio/ferlab/clin/portal/forms/models/submit/AdditionalInfo.java
@@ -1,0 +1,27 @@
+package bio.ferlab.clin.portal.forms.models.submit;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdditionalInfo {
+  
+  private Boolean isNewBorn;
+  private Boolean isPrenatalDiagnosis;
+  private String motherRamq;
+  
+  public void validate() {
+    if (Boolean.TRUE.equals(isNewBorn) && Boolean.TRUE.equals(isPrenatalDiagnosis)) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "patient.additional_info is_new_born and isPrenatalDiagnosis can't be both true");
+    }
+    if (Boolean.TRUE.equals(isNewBorn) && StringUtils.isBlank(motherRamq)) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "patient.additional_info is_new_born is true but mother_ramq is empty");
+    }
+  }
+}

--- a/src/main/java/bio/ferlab/clin/portal/forms/models/submit/Analyse.java
+++ b/src/main/java/bio/ferlab/clin/portal/forms/models/submit/Analyse.java
@@ -4,16 +4,17 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class Analyse {
-  @NotNull
+  @NotBlank
   private String panelCode;
   private Boolean isReflex;
-  @NotNull
+  @NotBlank
   private String indication;
   private String comment;
   private String residentSupervisor;

--- a/src/main/java/bio/ferlab/clin/portal/forms/models/submit/Exams.java
+++ b/src/main/java/bio/ferlab/clin/portal/forms/models/submit/Exams.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
@@ -18,11 +19,12 @@ public class Exams {
     normal
   }
   
-  @NotNull
+  @NotBlank
   private String code;
   @NotNull
   private Interpretation interpretation;
   private String value;
+  @NotNull
   private List<String> values = new ArrayList<>();
   
 }

--- a/src/main/java/bio/ferlab/clin/portal/forms/models/submit/Patient.java
+++ b/src/main/java/bio/ferlab/clin/portal/forms/models/submit/Patient.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
 
@@ -20,13 +22,13 @@ public class Patient {
     unknown
   }
   
-  @NotNull
+  @NotBlank
   private String ep;
   private String ramq;
   private String mrn;
-  @NotNull
+  @NotBlank
   private String firstName;
-  @NotNull
+  @NotBlank
   private String lastName;
   @NotNull
   @JsonFormat(pattern = "yyyy-MM-dd")
@@ -34,4 +36,7 @@ public class Patient {
   @NotNull
   private Gender gender;
   private String ethnicity;
+  @Valid
+  @NotNull
+  private AdditionalInfo additionalInfo = new AdditionalInfo();
 }

--- a/src/main/java/bio/ferlab/clin/portal/forms/models/submit/Signs.java
+++ b/src/main/java/bio/ferlab/clin/portal/forms/models/submit/Signs.java
@@ -4,13 +4,14 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class Signs {
-  @NotNull
+  @NotBlank
   private String value;
   @NotNull
   private Boolean isObserved;

--- a/src/main/java/bio/ferlab/clin/portal/forms/utils/FhirConst.java
+++ b/src/main/java/bio/ferlab/clin/portal/forms/utils/FhirConst.java
@@ -1,13 +1,15 @@
 package bio.ferlab.clin.portal.forms.utils;
 
-public class FhirConsts {
+public class FhirConst {
 
-  private FhirConsts(){}
+  private FhirConst(){}
   
   public static final String DEFAULT_HPO_SUFFIX = "-default-hpo";
   public static final String DEFAULT_EXAM_SUFFIX = "-default-exam";
   public static final String ABNORMALITIES_SUFFIX = "-abnormalities";
 
+  public static final String SYSTEM_MOTHER = "http://terminology.hl7.org/CodeSystem/v3-RoleCode";
+  public static final String CODE_MOTHER = "MTH";
   public static final String SYSTEM_RAMQ = "http://terminology.hl7.org/CodeSystem/v2-0203";
   public static final String CODE_RAMQ = "JHN";
   public static final String SYSTEM_MRN = "http://terminology.hl7.org/CodeSystem/v2-0203";

--- a/src/test/java/bio/ferlab/clin/portal/forms/mappers/FhirToSearchMapperTest.java
+++ b/src/test/java/bio/ferlab/clin/portal/forms/mappers/FhirToSearchMapperTest.java
@@ -1,7 +1,7 @@
 package bio.ferlab.clin.portal.forms.mappers;
 
 import bio.ferlab.clin.portal.forms.models.search.Search;
-import bio.ferlab.clin.portal.forms.utils.FhirConsts;
+import bio.ferlab.clin.portal.forms.utils.FhirConst;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Person;
 import org.hl7.fhir.r4.model.Reference;
@@ -18,11 +18,11 @@ class FhirToSearchMapperTest {
   @Test
   void mapToSearch() {
     final Patient patient = new Patient();
-    patient.getIdentifierFirstRep().setValue("mrn").getType().getCodingFirstRep().setSystem(FhirConsts.SYSTEM_MRN).setCode(FhirConsts.CODE_MRN);
+    patient.getIdentifierFirstRep().setValue("mrn").getType().getCodingFirstRep().setSystem(FhirConst.SYSTEM_MRN).setCode(FhirConst.CODE_MRN);
     patient.setManagingOrganization(new Reference().setReference("Organization/foo"));
     
     final Person person = new Person();
-    person.getIdentifierFirstRep().setValue("ramq").getType().getCodingFirstRep().setSystem(FhirConsts.SYSTEM_RAMQ).setCode(FhirConsts.CODE_RAMQ);
+    person.getIdentifierFirstRep().setValue("ramq").getType().getCodingFirstRep().setSystem(FhirConst.SYSTEM_RAMQ).setCode(FhirConst.CODE_RAMQ);
     final Date now = new Date();
     person.setBirthDate(now);
     person.getNameFirstRep().setFamily("lastname").addGiven("firstname");

--- a/src/test/java/bio/ferlab/clin/portal/forms/models/builders/AnalysisBuilderTest.java
+++ b/src/test/java/bio/ferlab/clin/portal/forms/models/builders/AnalysisBuilderTest.java
@@ -9,8 +9,8 @@ import org.mockito.Mockito;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
-import static bio.ferlab.clin.portal.forms.utils.FhirConsts.ANALYSIS_SERVICE_REQUEST;
-import static bio.ferlab.clin.portal.forms.utils.FhirConsts.SUPERVISOR_EXT;
+import static bio.ferlab.clin.portal.forms.utils.FhirConst.ANALYSIS_SERVICE_REQUEST;
+import static bio.ferlab.clin.portal.forms.utils.FhirConst.SUPERVISOR_EXT;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;

--- a/src/test/java/bio/ferlab/clin/portal/forms/models/builders/ClinicalImpressionBuilderTest.java
+++ b/src/test/java/bio/ferlab/clin/portal/forms/models/builders/ClinicalImpressionBuilderTest.java
@@ -9,7 +9,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
 
-import static bio.ferlab.clin.portal.forms.utils.FhirConsts.AGE_AT_EVENT_EXT;
+import static bio.ferlab.clin.portal.forms.utils.FhirConst.AGE_AT_EVENT_EXT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 

--- a/src/test/java/bio/ferlab/clin/portal/forms/models/builders/NewBornBuilderTest.java
+++ b/src/test/java/bio/ferlab/clin/portal/forms/models/builders/NewBornBuilderTest.java
@@ -1,0 +1,78 @@
+package bio.ferlab.clin.portal.forms.models.builders;
+
+import bio.ferlab.clin.portal.forms.mappers.SubmitToFhirMapper;
+import bio.ferlab.clin.portal.forms.models.submit.AdditionalInfo;
+import bio.ferlab.clin.portal.forms.utils.FhirConst;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.RelatedPerson;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NewBornBuilderTest {
+  
+  @Test
+  void build_missing_mother_ramq() {
+    final AdditionalInfo additionalInfo = new AdditionalInfo();
+    additionalInfo.setIsNewBorn(true);
+    final Patient patient = new Patient();
+    ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+      new NewBornBuilder(new SubmitToFhirMapper(), additionalInfo, patient).build();
+    });
+    assertEquals("patient.additional_info is_new_born is true but mother_ramq is empty", exception.getReason());
+    assertEquals(HttpStatus.BAD_REQUEST, exception.getStatus());
+  }
+
+  @Test
+  void build_foetus_and_new_born() {
+    final AdditionalInfo additionalInfo = new AdditionalInfo();
+    additionalInfo.setIsNewBorn(true);
+    additionalInfo.setIsPrenatalDiagnosis(true);
+    final Patient patient = new Patient();
+    ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+      new NewBornBuilder(new SubmitToFhirMapper(), additionalInfo, patient).build();
+    });
+    assertEquals("patient.additional_info is_new_born and isPrenatalDiagnosis can't be both true", exception.getReason());
+    assertEquals(HttpStatus.BAD_REQUEST, exception.getStatus());
+  }
+
+  @Test
+  void build_not_new_born() {
+    final AdditionalInfo additionalInfo = new AdditionalInfo();
+    additionalInfo.setIsNewBorn(false);
+    final Patient patient = new Patient();
+    NewBornBuilder.Result result = new NewBornBuilder(new SubmitToFhirMapper(), additionalInfo, patient).build();
+    assertNull(result.getRelatedPerson());
+  }
+
+  @Test
+  void build() {
+    final AdditionalInfo additionalInfo = new AdditionalInfo();
+    additionalInfo.setIsNewBorn(true);
+    additionalInfo.setMotherRamq("mother_ramq");
+    final Patient patient = new Patient();
+    patient.setId("mother_id");
+    
+    NewBornBuilder.Result result = new NewBornBuilder(new SubmitToFhirMapper(), additionalInfo, patient).build();
+    final RelatedPerson relatedPerson = result.getRelatedPerson();
+    
+    assertNotNull(relatedPerson.getId());
+    assertEquals("Patient/mother_id", relatedPerson.getPatient().getReference());
+    assertTrue(relatedPerson.getActive());
+    
+    final Identifier identifier = relatedPerson.getIdentifierFirstRep();
+    assertEquals("mother_ramq", identifier.getValue());
+    assertEquals(FhirConst.SYSTEM_RAMQ, identifier.getType().getCodingFirstRep().getSystem());
+    assertEquals(FhirConst.CODE_RAMQ, identifier.getType().getCodingFirstRep().getCode());
+    
+    final CodeableConcept relation = relatedPerson.getRelationshipFirstRep();
+    assertEquals("Mother", relation.getText());
+    assertEquals(FhirConst.SYSTEM_MOTHER, relation.getCodingFirstRep().getSystem());
+    assertEquals(FhirConst.CODE_MOTHER, relation.getCodingFirstRep().getCode());
+  }
+
+}

--- a/src/test/java/bio/ferlab/clin/portal/forms/models/builders/ObservationsBuilderTest.java
+++ b/src/test/java/bio/ferlab/clin/portal/forms/models/builders/ObservationsBuilderTest.java
@@ -15,7 +15,7 @@ import org.springframework.web.server.ResponseStatusException;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static bio.ferlab.clin.portal.forms.utils.FhirConsts.*;
+import static bio.ferlab.clin.portal.forms.utils.FhirConst.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ObservationsBuilderTest {

--- a/src/test/java/bio/ferlab/clin/portal/forms/models/builders/PatientBuilderTest.java
+++ b/src/test/java/bio/ferlab/clin/portal/forms/models/builders/PatientBuilderTest.java
@@ -3,7 +3,7 @@ package bio.ferlab.clin.portal.forms.models.builders;
 import bio.ferlab.clin.portal.forms.clients.FhirClient;
 import bio.ferlab.clin.portal.forms.mappers.SubmitToFhirMapper;
 import bio.ferlab.clin.portal.forms.models.submit.Patient;
-import bio.ferlab.clin.portal.forms.utils.FhirConsts;
+import bio.ferlab.clin.portal.forms.utils.FhirConst;
 import bio.ferlab.clin.portal.forms.utils.FhirUtils;
 import ca.uhn.fhir.context.FhirContext;
 import org.hl7.fhir.r4.model.Bundle;
@@ -41,6 +41,13 @@ class PatientBuilderTest {
     });
     assertEquals("patient.ramq and patient.mrn can't be both empty", exception.getReason());
     assertEquals(HttpStatus.BAD_REQUEST, exception.getStatus());
+  }
+
+  @Test
+  void validateRamqAndMrn_new_born() {
+      final Patient patient = new Patient();
+      patient.getAdditionalInfo().setIsNewBorn(true);
+      new PatientBuilder(fhirClient, new SubmitToFhirMapper(), patient).validateRamqAndMrn();
   }
   
   @Test
@@ -139,7 +146,7 @@ class PatientBuilderTest {
 
     final Bundle bundleByRamq = new Bundle();
     final Person person = new Person();
-    person.getIdentifierFirstRep().setValue("ramq").getType().getCodingFirstRep().setCode(FhirConsts.CODE_RAMQ).setSystem(FhirConsts.SYSTEM_RAMQ);
+    person.getIdentifierFirstRep().setValue("ramq").getType().getCodingFirstRep().setCode(FhirConst.CODE_RAMQ).setSystem(FhirConst.SYSTEM_RAMQ);
     bundleByRamq.addEntry().setResource(person);
     
     when(fhirClient.findPersonAndPatientByRamq(any())).thenReturn(bundleByRamq);

--- a/src/test/java/bio/ferlab/clin/portal/forms/models/builders/SequencingBuilderTest.java
+++ b/src/test/java/bio/ferlab/clin/portal/forms/models/builders/SequencingBuilderTest.java
@@ -7,7 +7,7 @@ import org.hl7.fhir.r4.model.PractitionerRole;
 import org.hl7.fhir.r4.model.ServiceRequest;
 import org.junit.jupiter.api.Test;
 
-import static bio.ferlab.clin.portal.forms.utils.FhirConsts.SEQUENCING_SERVICE_REQUEST;
+import static bio.ferlab.clin.portal.forms.utils.FhirConst.SEQUENCING_SERVICE_REQUEST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 


### PR DESCRIPTION
- [x] add `additional_info` body section (for new born and later foetus)
- [x] add `NewBornBuilder` to generate `RelatedPerson`
- [x] Allow empty Patient.mrn/ramq if new born 
- [x] rework some String validations: `NotNull` => `NotBlank`
- [x] Update README.md
- [x] TUs

Related PRs:
- https://github.com/Ferlab-Ste-Justine/clin-fhir-server/pull/136 (FHIR side validation of `RelatedPerson`)
- https://github.com/Ferlab-Ste-Justine/cqgc-pre-prod-service-configurations/pull/35 (Add `RelatedPerson` resource in Keycloak)